### PR TITLE
Fixed a warning when using with flutter_test

### DIFF
--- a/lib/src/dotenv.dart
+++ b/lib/src/dotenv.dart
@@ -66,7 +66,7 @@ class DotEnv {
   /// Logs to [stderr] if [filename] does not exist.
   Future load([String filename = '.env', Parser psr = const Parser()]) async {
     var lines = await _verify(filename);
-    env.addAll(psr.parse(lines));
+    _env.addAll(psr.parse(lines));
   }
 
   Future<List<String>> _verify(String filename) async {


### PR DESCRIPTION
Shell: [flutter_dotenv] No env values found. Make sure you have called DotEnv.load()

I believe this is because when doing env.addAll(psr.parse(lines)); inside the load method in dotenv.dart, it is using env as a getter, which is originally empty, as it is not yet set. Then, it is setting the value using the setter.

After the change, the message no longer shows and the env is still returned as expected.

![image](https://user-images.githubusercontent.com/17152619/64035158-b1d83880-cb15-11e9-9290-e9dcf1535052.png)

This is how I am using flutter_dotenv in the test to replicate.