### PR TITLE
Allow '=' characters in values

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -30,12 +30,12 @@ class Parser {
     var stripped = strip(line);
     if (!_isValid(stripped)) return {};
 
-    var sides = stripped.split('=');
-    var lhs = sides[0];
+    var idx = stripped.indexOf('=');
+    var lhs = stripped.substring(0, idx);
     var k = swallow(lhs);
     if (k.isEmpty) return {};
 
-    var rhs = sides[1].trim();
+    var rhs = stripped.substring(idx + 1, stripped.length).trim();
     var v = unquote(rhs);
 
     return {k: v};


### PR DESCRIPTION
## Description
- Currently, if a value has a `=` character in it the current parsing implementation does not work (i.e. a base64 encoded value).

## What changed
- Modified the parsing code to match a recent fix in the base repo [here](https://github.com/mockturtl/dotenv/pull/22/files)