### PR TITLE
Add an example/lib/main.dart for a prettier pub.dev presence

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+void main() async {
+  await DotEnv().load('.env');
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // Available anywhere in the app
+    final foo = DotEnv().env['foo'];
+    print('value of foo is $foo');
+
+    return MaterialApp(
+      home: Column(children: [
+        Text('foo is'),
+        Text(foo == null ? "(not defined)" : foo)
+      ]),
+    );
+  }
+}


### PR DESCRIPTION
Adds a sample main.dart to show usage in context.

I like the Examples tab in pub.dev, so I'm doing a best-effort PR to see if this could be enough.

If you see something wrong or missing, please shout :)