### PR TITLE
fix(test): make the testLoad method signature synchronous to match the body

### DIFF
--- a/lib/src/dotenv.dart
+++ b/lib/src/dotenv.dart
@@ -49,6 +49,19 @@ class DotEnv {
   /// Clear [env]
   void clean() => _envMap.clear();
 
+  String get(String name, {String? fallback}) {
+    final value = maybeGet(name, fallback: fallback);
+    assert(() {
+      if (value == null && fallback == null) {
+        throw AssertionError('A non-null fallback is required for missing entries');
+      }
+      return true;
+    }());
+    return value!;
+  }
+
+  String? maybeGet(String name, {String? fallback}) => env[name] ?? fallback;
+
   /// Loads environment variables from the env file into a map
   /// Merge with any entries defined in [mergeWith]
   Future<void> load(
@@ -62,8 +75,8 @@ class DotEnv {
     _isInitialized = true;
   }
 
-  Future<void> testLoad(
-      {String fileInput = '', Parser parser = const Parser(), Map<String, String> mergeWith = const {}}) async {
+  void testLoad(
+      {String fileInput = '', Parser parser = const Parser(), Map<String, String> mergeWith = const {}}) {
     clean();
     final linesFromFile = fileInput.split('\n');
     final linesFromMergeWith = mergeWith.entries.map((entry) => "${entry.key}=${entry.value}").toList();

--- a/test/dotenv_test.dart
+++ b/test/dotenv_test.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('dotenv', () {
     setUp(() {
       print(Directory.current.toString());
-      dotenv.testLoad(fileInput: File('test/.env').readAsStringSync()); //, mergeWith: Platform.environment
+      dotenv.testLoad(fileInput: File('test/.env').readAsStringSync()); // mergeWith: Platform.environment
     });
     test('able to load .env', () {
       expect(dotenv.env['FOO'], 'foo');
@@ -35,6 +35,16 @@ void main() {
       expect(dotenv.env['TRIM_SPACE_FROM_UNQUOTED'], 'some spaced out string');
       expect(dotenv.env['USERNAME'], 'therealnerdybeast@example.tld');
       expect(dotenv.env['SPACED_KEY'], 'parsed');
+    });
+    test('fallback getter works', () {
+      expect(dotenv.get('COMMENTS', fallback: 'sample'), 'sample');
+      expect(() => dotenv.get('COMMENTS'), throwsAssertionError);
+      expect(dotenv.get('EQUAL_SIGNS', fallback: 'sample'), 'equals==');
+    });
+    test('nullable fallback getter works', () {
+      expect(dotenv.maybeGet('COMMENTS', fallback: 'sample'), 'sample');
+      expect(dotenv.maybeGet('COMMENTS'), null);
+      expect(dotenv.maybeGet('EQUAL_SIGNS', fallback: 'sample'), 'equals==');
     });
   });
 }


### PR DESCRIPTION
Also added a small helper method to get non-null string values with a fallback default.