### PR TITLE
Allow --dart-define variables in .env file

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -24,8 +24,7 @@ class Parser {
   }
 
   /// Parses a single line into a key-value pair.
-  Map<String, String> parseOne(String line,
-      {Map<String, String> env = const {}}) {
+  Map<String, String> parseOne(String line, {Map<String, String> env = const {}}) {
     var stripped = strip(line);
     if (!_isValid(stripped)) return {};
 
@@ -49,8 +48,7 @@ class Parser {
   }
 
   /// Substitutes $bash_vars in [val] with values from [env].
-  String interpolate(String val, Map<String, String?> env) =>
-      val.replaceAllMapped(_bashVar, (m) {
+  String interpolate(String val, Map<String, String?> env) => val.replaceAllMapped(_bashVar, (m) {
         if ((m.group(1) ?? "") == "\\") {
           return m.input.substring(m.start, m.end);
         } else {
@@ -86,6 +84,5 @@ class Parser {
   bool _isValid(String s) => s.isNotEmpty && s.contains('=');
 
   /// [ null ] is a valid value in a Dart map, but the env var representation is empty string, not the string 'null'
-  bool _has(Map<String, String?> map, String key) =>
-      map.containsKey(key) && map[key] != null;
+  bool _has(Map<String, String?> map, String key) => map.containsKey(key) && map[key] != null;
 }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -24,7 +24,8 @@ class Parser {
   }
 
   /// Parses a single line into a key-value pair.
-  Map<String, String> parseOne(String line, {Map<String, String> env = const {}}) {
+  Map<String, String> parseOne(String line,
+      {Map<String, String> env = const {}}) {
     var stripped = strip(line);
     if (!_isValid(stripped)) return {};
 
@@ -48,12 +49,13 @@ class Parser {
   }
 
   /// Substitutes $bash_vars in [val] with values from [env].
-  String interpolate(String val, Map<String, String?> env) => val.replaceAllMapped(_bashVar, (m) {
+  String interpolate(String val, Map<String, String?> env) =>
+      val.replaceAllMapped(_bashVar, (m) {
         if ((m.group(1) ?? "") == "\\") {
           return m.input.substring(m.start, m.end);
         } else {
           var k = m.group(3)!;
-          if (!_has(env, k)) return '';
+          if (!_has(env, k)) return String.fromEnvironment(k);
           return env[k]!;
         }
       });
@@ -84,5 +86,6 @@ class Parser {
   bool _isValid(String s) => s.isNotEmpty && s.contains('=');
 
   /// [ null ] is a valid value in a Dart map, but the env var representation is empty string, not the string 'null'
-  bool _has(Map<String, String?> map, String key) => map.containsKey(key) && map[key] != null;
+  bool _has(Map<String, String?> map, String key) =>
+      map.containsKey(key) && map[key] != null;
 }


### PR DESCRIPTION
If the key is not in the env map then return String.fromEnvironment rather than always empty string