### PR TITLE
chore(docs): improve readme on where to add the `assets` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ ESCAPED_DOLLAR_SIGN='$1000'
 2. Add the `.env` file to your assets bundle in `pubspec.yaml`. **Ensure that the path corresponds to the location of the .env file!**
 
 ```yml
-assets:
-  - .env
+flutter:
+  assets:
+    - .env
 ```
 
 3. Remember to add the `.env` file as an entry in your `.gitignore` if it isn't already unless you want it included in your version control.


### PR DESCRIPTION
While this might seem obvious to some people, I struggled to use the library because it didn't say that the `assets` key should be added under the `flutter` key in the YAML configuration. I think this change simply makes it clearer.