### PR TITLE
fix: typed getters without fallback silently fail in release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Release notes are available on [github][notes].
 [pub-semver-readme]: https://pub.dartlang.org/packages/pub_semver
 [notes]: https://github.com/java-james/flutter_dotenv/releases
 
+# 6.0.1
+
+- [fix] Replace `assert()` with explicit `if`/`throw` in `getInt()`, `getDouble()`, and `getBool()` so null-safety checks are enforced in release builds (fixes #136)
+- Error messages now include the variable name for easier debugging
+
+### Note on release-build behavior change
+In **debug mode**, behavior is unchanged — `AssertionError` was thrown before, `AssertionError` is thrown now.
+
+In **release mode**, calling `getInt()`, `getDouble()`, or `getBool()` with a missing variable and no fallback previously threw a `TypeError` (from the null-check operator `!`) because `assert()` was stripped. It now correctly throws `AssertionError` with a descriptive message. If your release-mode code catches `on TypeError` around these methods, update it to catch `on AssertionError` (or `on Error`) instead.
+
 # 6.0.0
 
 - [feat] Allow passing in override .env files on init

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -118,26 +118,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/dotenv.dart
+++ b/lib/src/dotenv.dart
@@ -66,8 +66,10 @@ class DotEnv {
   /// exists but can not be parsed as an [int].
   int getInt(String name, {int? fallback}) {
     final value = maybeGet(name);
-    assert(value != null || fallback != null,
-        'A non-null fallback is required for missing entries');
+    if (value == null && fallback == null) {
+      throw AssertionError(
+          '$name variable not found. A non-null fallback is required for missing entries');
+    }
     return value != null ? int.parse(value) : fallback!;
   }
 
@@ -80,8 +82,10 @@ class DotEnv {
   /// exists but can not be parsed as a [double].
   double getDouble(String name, {double? fallback}) {
     final value = maybeGet(name);
-    assert(value != null || fallback != null,
-        'A non-null fallback is required for missing entries');
+    if (value == null && fallback == null) {
+      throw AssertionError(
+          '$name variable not found. A non-null fallback is required for missing entries');
+    }
     return value != null ? double.parse(value) : fallback!;
   }
 
@@ -94,8 +98,10 @@ class DotEnv {
   /// exists but can not be parsed as a [bool].
   bool getBool(String name, {bool? fallback}) {
     final value = maybeGet(name);
-    assert(value != null || fallback != null,
-        'A non-null fallback is required for missing entries');
+    if (value == null && fallback == null) {
+      throw AssertionError(
+          '$name variable not found. A non-null fallback is required for missing entries');
+    }
     if (value != null) {
       if (['true', '1'].contains(value.toLowerCase())) {
         return true;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -103,26 +103,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -201,5 +201,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/test/dotenv_test.dart
+++ b/test/dotenv_test.dart
@@ -132,5 +132,22 @@ void main() {
       expect(dotenv.getBool('COMMENTS', fallback: false), false);
       expect(() => dotenv.getBool('FOO'), throwsFormatException);
     });
+    test('typed getter errors include variable name', () {
+      expect(
+          () => dotenv.getInt('MISSING_VAR'),
+          throwsA(predicate((e) =>
+              e is AssertionError &&
+              e.message.toString().contains('MISSING_VAR'))));
+      expect(
+          () => dotenv.getDouble('MISSING_VAR'),
+          throwsA(predicate((e) =>
+              e is AssertionError &&
+              e.message.toString().contains('MISSING_VAR'))));
+      expect(
+          () => dotenv.getBool('MISSING_VAR'),
+          throwsA(predicate((e) =>
+              e is AssertionError &&
+              e.message.toString().contains('MISSING_VAR'))));
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Replace `assert()` with explicit `if`/`throw` in `getInt()`, `getDouble()`, and `getBool()` so null-safety checks work in release builds (fixes #136)
- Error messages now include the variable name for easier debugging
- Aligns typed getters with `get()`, which already uses explicit throws

## Problem

Dart strips `assert()` in release builds. When a variable was missing and no fallback was provided, release builds threw an opaque `Null check operator used on a null value` instead of a helpful error message.

## Note on release-build behavior

In release mode, the thrown exception type changes from `TypeError` (accidental, from `fallback!`) to `AssertionError` (intentional, matching debug mode). If your release code catches `on TypeError` around these methods, update to `on AssertionError` or `on Error`.

## Test plan

- [x] Existing `throwsAssertionError` tests continue to pass
- [x] New test verifies error messages contain the variable name
- [x] All 37 tests pass